### PR TITLE
Add link to original post for showcases

### DIFF
--- a/src/handlers/showcase.ts
+++ b/src/handlers/showcase.ts
@@ -20,7 +20,7 @@ export default async function handleShowcaseMessage(
           `40s channel posted showcase: ${msg.author.username} ${url}`
         );
         await showcaseChannel.send(
-          `Posted by: ${msg.author.toString()}`,
+          `Posted by: ${msg.author.toString()}\nOP: ${msg.url}`,
           attachment
         );
         return;


### PR DESCRIPTION
Simply adds a link to the original message for showcase posts. Hyperlinks can't be used unless showcase posts are wrapped in embeds.