### PR TITLE
Project QoL Enhancements

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -30,6 +30,7 @@ async function handleMessage(msg: Message, client: Client): Promise<void> {
 async function handleReaction(
   reaction: MessageReaction,
   user: User | PartialUser,
+  action: 'add' | 'remove',
   client: Client
 ): Promise<void> {
   if (user.partial) {
@@ -59,7 +60,7 @@ async function handleReaction(
   // Assume the user is no longer partial since we handled that above
   if (reaction.message.guild?.id === config.FORTIES_GUILD) {
     await handleIcGbReviewReaction(reaction, client, user as User);
-    await handleProjectAnnouncementReaction(reaction, user as User);
+    await handleProjectAnnouncementReaction(reaction, user as User, action);
   }
 }
 

--- a/src/handlers/project/create.ts
+++ b/src/handlers/project/create.ts
@@ -141,14 +141,13 @@ async function announceProject(
   const serializedParams = AnnouncementParams.serialize(
     projectAnnouncementParams
   );
-  await announceChannel.send(
+  const msg = await announceChannel.send(
     `Announcing the ${reviewParams.type} for ${reviewParams.name} by <@${reviewParams.ownerId}>!
 ${reviewParams.description}
 To gain access to the project channel <#${channel.id}>, join the role <@&${projectAnnouncementParams.roleId}> by reacting to this announcement with :white_check_mark:!`,
     [new MessageAttachment(reviewParams.imageUrl), serializedParams]
   );
-  // TODO: when a user reacts to the announcement, give them the role
-  // :white_check_mark: for accept :eyes: for gb role
+  await msg.react('✅');
 }
 
 export default {

--- a/src/handlers/project/index.ts
+++ b/src/handlers/project/index.ts
@@ -41,10 +41,11 @@ async function handleIcGbRequestMessage(
       const reviewChannel = (await client.channels.fetch(
         config.IC_GB_REVIEW_CHANNEL
       )) as TextChannel;
-      await reviewChannel.send(reviewMessage, [
+      const message = (await reviewChannel.send(reviewMessage, [
         new MessageAttachment(requestParams.imageUrl),
         serializedParams,
-      ]);
+      ]));
+      await message.react('✅');
     } catch (error) {
       return;
     }

--- a/src/handlers/project/index.ts
+++ b/src/handlers/project/index.ts
@@ -98,7 +98,8 @@ async function handleIcGbReviewReaction(
 
 async function handleProjectAnnouncementReaction(
   reaction: MessageReaction,
-  user: User
+  user: User,
+  action: 'add' | 'remove'
 ): Promise<void> {
   // Only handle reactions in the IC/GB review channel
   if (reaction.message.channel.id !== config.IC_GB_ANNOUNCE_CHANNEL) {
@@ -115,7 +116,17 @@ async function handleProjectAnnouncementReaction(
     const projectParams = response.data;
     const guild = reaction.message.guild as Guild;
     const member = await guild.members.fetch(user.id);
-    await member.roles.add(projectParams.roleId);
+
+    switch (action) {
+      case 'add': {
+        await member.roles.add(projectParams.roleId);
+        break;
+      }
+      case 'remove': {
+        await member.roles.remove(projectParams.roleId);
+        break;
+      }
+    }
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,22 +18,29 @@ client.on('ready', () => {
 });
 
 // We use these wrappers because typescript eslint will throw a fit if we return
-//  and unresolved promise instead of void in the client handlers.
+//  an unresolved promise instead of void in the client handlers.
 function handleMessageSyncWrapper(msg: Message): void {
   void handleMessageAsync(msg, client);
 }
 
 // We use these wrappers because typescript eslint will throw a fit if we return
-//  and unresolved promise instead of void in the client handlers.
+//  an unresolved promise instead of void in the client handlers.
 function handleReactionSyncWrapper(
   reaction: MessageReaction,
-  user: User | PartialUser
+  user: User | PartialUser,
+  action: 'add' | 'remove'
 ): void {
-  void handleReactionAsync(reaction, user, client);
+  void handleReactionAsync(reaction, user, action, client);
 }
 
 client.on('message', handleMessageSyncWrapper);
 
-client.on('messageReactionAdd', handleReactionSyncWrapper);
+client.on('messageReactionAdd', (messageReaction, user) =>
+  handleReactionSyncWrapper(messageReaction, user, 'add')
+);
+
+client.on('messageReactionRemove', (messageReaction, user) =>
+  handleReactionSyncWrapper(messageReaction, user, 'remove')
+);
 
 void client.login(config.BOT_TOKEN);


### PR DESCRIPTION
Closes #23, Closes #37

Removing a ✅ reaction from a message in the `#ic-gb-announcements` now removes the role from the user.

The bot now reacts to it's own messages in #ic-gb-review and #ic-gb-announcements with a ✅ emoji

![](https://cdn.discordapp.com/attachments/817626497896022028/822696149672263680/unknown.png)

![](https://cdn.discordapp.com/attachments/817626497896022028/822696291829153802/unknown.png)