### PR TITLE
feat(showcase): showcase embeds

### DIFF
--- a/src/handlers/showcase.ts
+++ b/src/handlers/showcase.ts
@@ -1,4 +1,4 @@
-import { Message, Client, MessageAttachment, TextChannel } from 'discord.js';
+import { Message, Client, TextChannel, MessageEmbed } from 'discord.js';
 import config from '../config';
 
 export default async function handleShowcaseMessage(
@@ -15,14 +15,24 @@ export default async function handleShowcaseMessage(
     await Promise.all(
       msg.attachments.map(async (each) => {
         const url = each.proxyURL;
-        const attachment = new MessageAttachment(url);
         console.log(
           `40s channel posted showcase: ${msg.author.username} ${url}`
         );
-        await showcaseChannel.send(
-          `Posted by: ${msg.author.toString()}\nOP: ${msg.url}`,
-          attachment
-        );
+        const embed = new MessageEmbed()
+          .setAuthor(
+            msg.author.username,
+            msg.author.avatarURL() ?? msg.author.defaultAvatarURL
+          )
+          .setDescription(
+            msg.content.replace(
+              new RegExp(`^<#${config.FORTIES_SHOWCASE}>\\s*`),
+              ''
+            )
+          )
+          .addField('Original Message', `[🔗](${msg.url})`)
+          .setTimestamp()
+          .setImage(url);
+        await showcaseChannel.send(embed);
         return;
       })
     );


### PR DESCRIPTION
Closes #14 

Puts the `#showcase` posts in embeds and includes the message content (without the `#showcase` bit) as a description of the image.

![message](https://i.imgur.com/ArGLvDW.png)

![showcase](https://i.imgur.com/qsGQce3.png)

The 🔗 emoji is a clickable link to the original message.