### PR TITLE
feat(soundtest): add url and attachment validation to soundtest

### DIFF
--- a/src/handlers/soundtest.ts
+++ b/src/handlers/soundtest.ts
@@ -1,16 +1,40 @@
-import { Message, Client, TextChannel } from 'discord.js';
+import { Message, MessageAttachment, Client, TextChannel } from 'discord.js';
 import config from '../config';
+import containsValidUrl from '../utils/containsValidUrl';
 
 export default async function handleSoundtestMessage(
   msg: Message,
   client: Client
 ): Promise<void> {
-  if (msg.content.includes(config.FORTIES_SOUNDTEST)) {
-    const url = msg.content.split(`<#${config.FORTIES_SOUNDTEST}> `)[1];
-    console.log(`40s channel posted soundtest: ${msg.author.username} ${url}`);
+  if (
+    msg.content.includes(config.FORTIES_SOUNDTEST) &&
+    msg.channel.id !== config.FORTIES_SOUNDTEST
+  ) {
     const soundTestChannel = (await client.channels.fetch(
       config.FORTIES_SOUNDTEST
     )) as TextChannel;
-    await soundTestChannel.send(`Posted by: ${msg.author.toString()}\n${url}`);
+    const filteredUserInput = msg.content
+      .replace(new RegExp(`<#${config.FORTIES_SOUNDTEST}>`), '')
+      .trim();
+    const validUrlPresent = containsValidUrl(filteredUserInput);
+    const attachmentUrl = msg.attachments?.first()?.url;
+
+    if (validUrlPresent || !!attachmentUrl) {
+      let messageToSend = `Posted by: ${msg.author.toString()}`;
+      if (filteredUserInput) messageToSend += `\n${filteredUserInput}`;
+      console.log(
+        `40s channel posted soundtest: ${msg.author.username} ${filteredUserInput}`
+      );
+      if (attachmentUrl) {
+        const attachment = new MessageAttachment(attachmentUrl);
+        await soundTestChannel.send(messageToSend, attachment);
+      } else {
+        await soundTestChannel.send(messageToSend);
+      }
+    } else {
+      await msg.reply(
+        'sound tests must contain a valid url and/or attachment.'
+      );
+    }
   }
 }

--- a/src/utils/containsValidUrl.ts
+++ b/src/utils/containsValidUrl.ts
@@ -1,0 +1,7 @@
+export default function containsValidUrl(content: string): boolean {
+  if (content.length === 0 || typeof content != 'string') return false;
+
+  // see https://stackoverflow.com/questions/1500260/detect-urls-in-text-with-javascript
+  const validUrlRegex = /(\bhttps?:\/\/[-A-Z0-9+&@#%?=~_|!:,.;]*[-A-Z0-9+&@#%=~_|])/gi;
+  return validUrlRegex.test(content);
+}


### PR DESCRIPTION
Closes #12 with the following changes:

- Ensures that a sound test post requires either a valid url or attachment
- Adds additional flexibility to the request format
- Addresses an issue where the bot was picking up sound test requests inside of the sound test channel 
- Adds user feedback to remind them of sound test criteria if their request does not include either/or
- Creates a utils directory for reusable snippets