### PR TITLE
feat(project): improve error messaging for project requests

### DIFF
--- a/src/handlers/project/index.ts
+++ b/src/handlers/project/index.ts
@@ -34,7 +34,7 @@ async function handleIcGbRequestMessage(
 ): Promise<void> {
   if (msg.channel.id == config.IC_GB_REQUEST_CHANNEL) {
     try {
-      const requestParams = await RequestParams.parse(msg, client);
+      const requestParams = await RequestParams.parse(msg);
       const reviewParams = ReviewParams.fromRequestParams(requestParams);
       const reviewMessage = formatIcGbReviewMessage(reviewParams);
       const serializedParams = ReviewParams.serialize(reviewParams);

--- a/src/handlers/project/requestParams.ts
+++ b/src/handlers/project/requestParams.ts
@@ -1,5 +1,4 @@
-import { Snowflake, Message, Client, TextChannel } from 'discord.js';
-import config from '../../config';
+import { Snowflake, Message } from 'discord.js';
 
 type ProjectRequestParams = {
   type: string;
@@ -9,32 +8,42 @@ type ProjectRequestParams = {
   imageUrl: string;
 };
 
-async function parse(
-  msg: Message,
-  client: Client
-): Promise<ProjectRequestParams> {
+async function parse(msg: Message): Promise<ProjectRequestParams> {
   const lines = msg.content.split('\n');
+
   if (lines.length >= 3) {
-    const type = lines[0];
-    const name = lines[1];
-    const description = lines.slice(2).join('\n');
-    const typeValid = type == 'IC' || type == 'GB';
+    const errors = [];
+    const type = lines[0].trim();
+    const name = lines[1].trim();
+    const description = lines.slice(2).join('\n').trim();
+    const descriptionLineCount = lines.slice(2).length;
+    const typeValid = ['IC', 'GB'].includes(type);
     const nameValid = name.length > 0 && name.length < 32;
     const descriptionValid =
       description.length > 0 &&
       description.length <= 1000 &&
       lines.length <= 15;
     const attachmentUrls = msg.attachments.map((attachment) => attachment.url);
-    if (attachmentUrls.length !== 1) {
-      const requestChannel = (await client.channels.fetch(
-        config.IC_GB_REQUEST_CHANNEL
-      )) as TextChannel;
-      await requestChannel.send(
-        'Please attach exactly one image for representing your project in the announcement.'
+
+    if (!typeValid)
+      errors.push(
+        `Type (line one) must be either "IB" or "GB". You entered "${type}".`
       );
-      throw Error('FormatError');
-    }
-    if (typeValid && nameValid && descriptionValid) {
+    if (!nameValid)
+      errors.push(
+        `Project name (line two) must be fewer than 32 characters. Your's was ${name.length} characters.`
+      );
+    if (!descriptionValid)
+      errors.push(
+        `Project description (line three+) must be fewer than 1000 characters and/or fewer than 15 lines.
+       Your description was ${description.length} characters and ${descriptionLineCount} lines.`
+      );
+    if (attachmentUrls.length !== 1)
+      errors.push(
+        `Request must have exactly one image attached. Your request had ${attachmentUrls.length} attachments.`
+      );
+
+    if (errors.length === 0) {
       return {
         type,
         name,
@@ -42,13 +51,22 @@ async function parse(
         description,
         imageUrl: attachmentUrls[0],
       };
+    } else {
+      let errorMessage = `your request had the following issues:`;
+      for (const error of errors) {
+        errorMessage += `\n   - ${error}`;
+      }
+      await msg.reply(errorMessage);
+      throw Error('FormatError');
     }
   }
-  const requestErrorMessage = `Wrong format or missing parameters.`;
-  const requestChannel = (await client.channels.fetch(
-    config.IC_GB_REQUEST_CHANNEL
-  )) as TextChannel;
-  await requestChannel.send(requestErrorMessage);
+  const requestErrorMessage = `your request was incomplete. Please ensure your request matches the following format:
+    - Line one: "IC" (Interest Check) or "GB" (Group Buy)
+    - Line two: Project name (less than 32 characters)
+    - Line three+: Project description (up to 1000 characters and/or up to 12 lines)
+    - Must include exactly one attachment to be used with the announcement
+  `;
+  await msg.reply(requestErrorMessage);
   throw Error('FormatError');
 }
 

--- a/src/handlers/project/requestParams.ts
+++ b/src/handlers/project/requestParams.ts
@@ -40,7 +40,7 @@ async function parse(msg: Message): Promise<ProjectRequestParams> {
       );
     if (attachmentUrls.length !== 1)
       errors.push(
-        `Request must have exactly one image attached. Your request had ${attachmentUrls.length} attachments.`
+        `Request must have exactly one image attached (not a URL). Your request had ${attachmentUrls.length} attachments.`
       );
 
     if (errors.length === 0) {
@@ -64,7 +64,7 @@ async function parse(msg: Message): Promise<ProjectRequestParams> {
     - Line one: "IC" (Interest Check) or "GB" (Group Buy)
     - Line two: Project name (less than 32 characters)
     - Line three+: Project description (up to 1000 characters and/or up to 12 lines)
-    - Must include exactly one attachment to be used with the announcement
+    - Must include exactly one image attachment (not a URL) to be used with the announcement
   `;
   await msg.reply(requestErrorMessage);
   throw Error('FormatError');


### PR DESCRIPTION
Closes #19 

Enhances the error messaging around project requests and handles all messaging as direct replies to the submitter. 

All error messages should now be much more precise. If the request itself is less than three lines then the project requester is reminded of the general requirements. Otherwise they are told which requirements they did not meet and why.  

<img width="885" alt="Screen Shot 2021-03-12 at 11 03 05 PM" src="https://user-images.githubusercontent.com/38873908/111019975-3dc45500-8388-11eb-908f-f2fbd80cf6b2.png">
