### PR TITLE
Showcase embed channel names, logging, and missing URL prevention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 build
 .eslintcache
+.vscode/

--- a/src/handlers/showcase.ts
+++ b/src/handlers/showcase.ts
@@ -13,10 +13,8 @@ export default async function handleShowcaseMessage(
       config.FORTIES_SHOWCASE
     )) as TextChannel;
 
-    const url = msg.attachments.first()?.proxyURL as string
-    console.log(
-      `40s channel posted showcase: ${msg.author.username} ${url}`
-    );
+    const url = msg.attachments.first()?.proxyURL as string;
+    console.log(`40s channel posted showcase: ${msg.author.username} ${url}`);
 
     const embed = new MessageEmbed()
       .setAuthor(
@@ -24,14 +22,15 @@ export default async function handleShowcaseMessage(
         msg.author.avatarURL() ?? msg.author.defaultAvatarURL
       )
       .setDescription(
-        msg.content.replace(
-          `<#${config.FORTIES_SHOWCASE}>`,
-          ''
-        ).trim().substring(0, 512)
+        msg.content
+          .replace(`<#${config.FORTIES_SHOWCASE}>`, '')
+          .trim()
+          .substring(0, 512)
       )
       .addField('Original Message', `[Jump 🔗](${msg.url})`, true)
-      .setTimestamp()
-      .setImage(url);
+      .setImage(url)
+      .setFooter(`#${(msg.channel as TextChannel).name}`)
+      .setTimestamp();
 
     await showcaseChannel.send(embed);
     return;

--- a/src/handlers/showcase.ts
+++ b/src/handlers/showcase.ts
@@ -14,7 +14,21 @@ export default async function handleShowcaseMessage(
     )) as TextChannel;
 
     const url = msg.attachments.first()?.proxyURL as string;
-    console.log(`40s channel posted showcase: ${msg.author.username} ${url}`);
+
+    if (!url) {
+      console.log('Missing showcase image:');
+      console.log({
+        author: msg.author.tag,
+        message_url: msg.url,
+      });
+      console.log('\n');
+
+      await msg.reply(
+        "something went wrong. We'll take a look, but in the meantime please ensure an image is attached and try again."
+      );
+
+      return;
+    }
 
     const embed = new MessageEmbed()
       .setAuthor(
@@ -32,7 +46,16 @@ export default async function handleShowcaseMessage(
       .setFooter(`#${(msg.channel as TextChannel).name}`)
       .setTimestamp();
 
-    await showcaseChannel.send(embed);
+    const embedMessage = await showcaseChannel.send(embed);
+
+    console.log('40s channel posted showcase:');
+    console.log({
+      author: msg.author.tag,
+      image_url: url,
+      message_url: embedMessage.url,
+    });
+    console.log('\n');
+
     return;
   }
 }

--- a/src/handlers/showcase.ts
+++ b/src/handlers/showcase.ts
@@ -16,12 +16,10 @@ export default async function handleShowcaseMessage(
     const url = msg.attachments.first()?.proxyURL as string;
 
     if (!url) {
-      console.log('Missing showcase image:');
-      console.log({
+      console.log('Missing showcase image:', {
         author: msg.author.tag,
         message_url: msg.url,
       });
-      console.log('\n');
 
       await msg.reply(
         "something went wrong. We'll take a look, but in the meantime please ensure an image is attached and try again."
@@ -30,17 +28,21 @@ export default async function handleShowcaseMessage(
       return;
     }
 
+    const trimDescription = (content: string): string => {
+      const trimmedContent = content
+        .replace(`<#${config.FORTIES_SHOWCASE}>`, '')
+        .trim();
+      return trimmedContent.length > 512
+        ? `${trimmedContent.substring(0, 512).trim()}...`
+        : trimmedContent;
+    };
+
     const embed = new MessageEmbed()
       .setAuthor(
         msg.author.username,
         msg.author.avatarURL() ?? msg.author.defaultAvatarURL
       )
-      .setDescription(
-        msg.content
-          .replace(`<#${config.FORTIES_SHOWCASE}>`, '')
-          .trim()
-          .substring(0, 512)
-      )
+      .setDescription(trimDescription(msg.content))
       .addField('Original Message', `[Jump 🔗](${msg.url})`, true)
       .setImage(url)
       .setFooter(`#${(msg.channel as TextChannel).name}`)
@@ -48,13 +50,11 @@ export default async function handleShowcaseMessage(
 
     const embedMessage = await showcaseChannel.send(embed);
 
-    console.log('40s channel posted showcase:');
-    console.log({
+    console.log('40s channel posted showcase:', {
       author: msg.author.tag,
       image_url: url,
       message_url: embedMessage.url,
     });
-    console.log('\n');
 
     return;
   }


### PR DESCRIPTION
Relates to #46 

Added the name of the channel of the posted image to the showcase embed

![](https://cdn.discordapp.com/attachments/751214214689063013/822681206218031124/unknown.png)

Added a prevention for posts missing a URL.

Added more detailed logging for showcase posts. Example log entry: 
```bash
40s channel posted showcase: {
  author: 'kidpid#5769',
  image_url: 'https://media.discordapp.net/attachments/817626497896022028/822708698274201630/70726196.jpg',
  message_url: 'https://discord.com/channels/817626497442512918/817627158456303666/822708699620573184'
}
```