### PR TITLE
fix(project): correct small typo in error msg

### DIFF
--- a/src/handlers/project/requestParams.ts
+++ b/src/handlers/project/requestParams.ts
@@ -27,7 +27,7 @@ async function parse(msg: Message): Promise<ProjectRequestParams> {
 
     if (!typeValid)
       errors.push(
-        `Type (line one) must be either "IB" or "GB". You entered "${type}".`
+        `Type (line one) must be either "IC" or "GB". You entered "${type}".`
       );
     if (!nameValid)
       errors.push(


### PR DESCRIPTION
Fixes a small typo that was missed in the error messaging for project requests.

Closes #48 