### PR TITLE
fix(showcase): changed from proxyURL to url for showcase embed images

### DIFF
--- a/src/handlers/showcase.ts
+++ b/src/handlers/showcase.ts
@@ -13,7 +13,7 @@ export default async function handleShowcaseMessage(
       config.FORTIES_SHOWCASE
     )) as TextChannel;
 
-    const url = msg.attachments.first()?.proxyURL as string;
+    const url = msg.attachments.first()?.url as string;
 
     if (!url) {
       console.log('Missing showcase image:', {


### PR DESCRIPTION
Fixes #46 

A simple change from using the `proxyURL` field to the `url` field from the [MessageAttachment](https://discord.js.org/#/docs/main/stable/class/MessageAttachment) object. I did some testing with some messages that previously failed, and while I was able to duplicate the issue some of the time when using `proxyURL`; I was never able to duplicate the issue using `url`. It would appear that `proxyURL` loads slower than `url` does.