### PR TITLE
feat(showcase): use url of first valid image file extension found

### DIFF
--- a/src/handlers/showcase.ts
+++ b/src/handlers/showcase.ts
@@ -12,8 +12,17 @@ export default async function handleShowcaseMessage(
     const showcaseChannel = (await client.channels.fetch(
       config.FORTIES_SHOWCASE
     )) as TextChannel;
+    let url;
 
-    const url = msg.attachments.first()?.url as string;
+    if (msg.attachments.size > 1) {
+      const acceptedFileFormats = new RegExp('.(jpe?g|png|gif|bmp)$', 'i');
+      const attachmentToUse = msg.attachments.find((attachment) =>
+        acceptedFileFormats.test(attachment.url)
+      );
+      if (attachmentToUse) url = attachmentToUse.url ;
+    } else {
+      url = msg.attachments.first()?.url as string;
+    }
 
     if (!url) {
       console.log('Missing showcase image:', {


### PR DESCRIPTION
Updates the showcase logic to use the url of the first valid image file extension found in the attachments array. 

Closes #51