### PR TITLE
chore(showcase): added more of the image info to showcase logging

### DIFF
--- a/src/handlers/showcase.ts
+++ b/src/handlers/showcase.ts
@@ -73,8 +73,8 @@ export default async function handleShowcaseMessage(
 
     console.log('40s channel posted showcase:', {
       author: msg.author.tag,
-      image_url: image.url,
       message_url: embedMessage.url,
+      image: embed.image,
     });
 
     return;


### PR DESCRIPTION
Added the image object to the showcase logs:

```
image: {
  url: <string>,
  proxyURL: <string>,
  height: <number>,
  width: <number>,
}
```

Example log:
```bash
40s channel posted showcase: {
  author: 'kidpid#5769',
  message_url: 'https://discord.com/channels/817626497442512918/817627158456303666/838772484592631849',
  image: {
    url: 'https://cdn.discordapp.com/attachments/817626497896022028/838772483468951563/phoenix.png',
    proxyURL: 'https://media.discordapp.net/attachments/817626497896022028/838772483468951563/phoenix.png',
    height: 1854,
    width: 3501
  }
}
```