### PR TITLE
fix(project): sort category channels on creation

### DIFF
--- a/src/handlers/project/create.ts
+++ b/src/handlers/project/create.ts
@@ -55,7 +55,7 @@ async function createProjectRole(
     config.BOT_COMMANDS_CHANNEL
   )) as TextChannel;
   await botCommandsChannel.send(
-    `<@${reviewerId}> please enter \`?addrank ${roleName}\` to create the project rank, and remember to organize channels by alphabetical order`
+    `<@${reviewerId}> please enter \`?addrank ${roleName}\` to create the project rank.`
   );
   return role;
 }


### PR DESCRIPTION
After a new channel is created for an IC or GB, sort the category.
This is to eliminate the chore of mods sorting channels every time.

Closes #60