### PR TITLE
feat(showcase): changed the "Original Message" field to a link button

### DIFF
--- a/src/handlers/showcase.ts
+++ b/src/handlers/showcase.ts
@@ -1,4 +1,11 @@
-import { Message, Client, TextChannel, MessageEmbed } from 'discord.js';
+import {
+  Message,
+  Client,
+  TextChannel,
+  MessageEmbed,
+  MessageActionRow,
+  MessageButton,
+} from 'discord.js';
 import config from '../config';
 
 export default async function handleShowcaseMessage(
@@ -44,13 +51,6 @@ export default async function handleShowcaseMessage(
         icon_url: msg.author.avatarURL() ?? msg.author.defaultAvatarURL,
       },
       description: trimDescription(msg.content),
-      fields: [
-        {
-          name: 'Original Message',
-          value: `[Jump 🔗](${msg.url})`,
-          inline: false,
-        },
-      ],
       image: {
         url: image.url,
         proxyURL: image.proxyURL,
@@ -63,7 +63,17 @@ export default async function handleShowcaseMessage(
       },
     });
 
-    const embedMessage = await showcaseChannel.send({ embeds: [embed] });
+    const msgLinkButton = new MessageActionRow().addComponents(
+      new MessageButton()
+        .setLabel('Original Message')
+        .setStyle('LINK')
+        .setURL(msg.url)
+    );
+
+    const embedMessage = await showcaseChannel.send({
+      embeds: [embed],
+      components: [msgLinkButton],
+    });
 
     console.log('40s channel posted showcase:', {
       author: msg.author.tag,


### PR DESCRIPTION
Moved the embed field for the "Original Message" link to a link button.

![](https://media.discordapp.net/attachments/751214214689063013/890075618933358602/unknown.png)