### PR TITLE
feat(bst): enforce location in BST

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ IC_CATEGORY=etc
 GB_CATEGORY=etc
 WALLET_DESTROYER_ROLE=etc
 BOT_COMMANDS_CHANNEL=etc
+BUY_SELL_TRADE_CHANNEL=etc
+BUY_SELL_TRADE_DISCUSSION_CHANNEL=etc
 ```
 
 These values will be picked up by the bot application to be able to run correctly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@discordjs/rest": "^0.1.1-canary.0",
         "@types/node-fetch": "^2.5.10",
         "axios": "^0.21.0",
+        "country-code-lookup": "^0.0.19",
         "discord-api-types": "^0.23.1",
         "discord.js": "^13.1.0",
         "slugify": "^1.4.6"
@@ -1489,6 +1490,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/country-code-lookup": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/country-code-lookup/-/country-code-lookup-0.0.19.tgz",
+      "integrity": "sha512-lpvgdPyj8RuP0CSZhACNf5ueKlLbv/IQUAQfg7yr/qJbFrdcWV7Y+aDN9K/u/bx3MXRfcsjuW+TdIc0AEj7kDw=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6085,6 +6091,11 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "country-code-lookup": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/country-code-lookup/-/country-code-lookup-0.0.19.tgz",
+      "integrity": "sha512-lpvgdPyj8RuP0CSZhACNf5ueKlLbv/IQUAQfg7yr/qJbFrdcWV7Y+aDN9K/u/bx3MXRfcsjuW+TdIc0AEj7kDw=="
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@discordjs/rest": "^0.1.1-canary.0",
     "@types/node-fetch": "^2.5.10",
     "axios": "^0.21.0",
+    "country-code-lookup": "^0.0.19",
     "discord-api-types": "^0.23.1",
     "discord.js": "^13.1.0",
     "slugify": "^1.4.6"

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -12,5 +12,7 @@ declare namespace NodeJS {
     GB_CATEGORY: string;
     WALLET_DESTROYER_ROLE: string;
     BOT_COMMANDS_CHANNEL: string;
+    BUY_SELL_TRADE_CHANNEL: string;
+    BUY_SELL_TRADE_DISCUSSION_CHANNEL: string;
   }
 }

--- a/src/handlers/buyselltrade.ts
+++ b/src/handlers/buyselltrade.ts
@@ -1,0 +1,47 @@
+import { Message, Client, Formatters, TextChannel } from 'discord.js';
+import { byInternet } from 'country-code-lookup';
+import config from '../config';
+
+const containsValidLocation = (msg: string) => {
+  const locationFormat =
+    /[[({]{1}([a-zA-Z]{2,3})(-([a-zA-Z]{2,4}))?[\])}]{1}/im;
+  const location = locationFormat.exec(msg);
+
+  if (!location) return false;
+
+  return location.some((v) => (v ? byInternet(v) : false));
+};
+
+export default async function handleBuySellTradeMessage(
+  msg: Message,
+  client: Client
+): Promise<void> {
+  if (msg.channel.id !== config.BUY_SELL_TRADE_CHANNEL) return;
+  if (
+    msg.channel.isThread() ||
+    ['THREAD_STARTER_MESSAGE', 'THREAD_CREATED'].includes(msg.type)
+  )
+    return;
+  if (containsValidLocation(msg.content)) return;
+
+  const buySellTradeDiscussionChannel = (await client.channels.fetch(
+    config.BUY_SELL_TRADE_DISCUSSION_CHANNEL
+  )) as TextChannel;
+  const msgCopy = Formatters.blockQuote(msg.content);
+
+  await msg
+    .delete()
+    .then((msg) =>
+      console.log(
+        `Deleted message in BST from ${msg.author.username} for missing location or invalid formatting: ${msg.content}`
+      )
+    )
+    .catch(console.error);
+
+  await buySellTradeDiscussionChannel.send(`
+  ${Formatters.userMention(
+    msg.author.id
+  )}, your request was removed because it lacked a valid country code or the formatting was invalid. Please review the BST rules and resubmit your message:
+  ${msgCopy}
+`);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import {
   User,
   Interaction,
 } from 'discord.js';
+import handleBuySellTradeMessage from './handlers/buyselltrade';
 import handleShowcaseMessage from './handlers/showcase';
 import handleSoundtestMessage from './handlers/soundtest';
 import {
@@ -73,6 +74,7 @@ client.on('messageCreate', async (msg) => {
   if (!messageShouldBeHandled(msg)) return;
 
   await callHandlers(
+    handleBuySellTradeMessage(msg, client),
     handleShowcaseMessage(msg, client),
     handleSoundtestMessage(msg, client),
     handleIcGbRequestMessage(msg, client)


### PR DESCRIPTION
Adds a new feature that removes messages from BST automatically if they do not contain a location in brackets. This will ignore any thread messages.

This will require you to add the channel ids for BST and BST Discussion to your .env file as:

BUY_SELL_TRADE_CHANNEL="channel id"
BUY_SELL_TRADE_DISCUSSION_CHANNEL="channel id"

To test this, after youve created a local bst and bst discussion channel try to create several messages along the following:
- Message must contain a location tag inside of two [], (), {} or any combo and must contain a valid country code (2-3 characters) on either side of a dash (if present), e.g., `[US-CT]`, e.g.,:
![bst1](https://user-images.githubusercontent.com/38873908/136661865-eee9ac8d-d664-41bb-be83-f65d49bdf2b9.png)
- If an invalid BST post is created it should immediately be deleted by the bot
- A console log should be created noting that a message was removed for that user:
 ![bst3](https://user-images.githubusercontent.com/38873908/136661759-0c742cee-e62d-4304-b7c6-5c90a65bfea4.png)
- A message should then be created in the BST Discussion channel notifying the user that created it:
![bst2](https://user-images.githubusercontent.com/38873908/136661753-0c40129c-65d3-4d26-9d4f-9268adf2d47f.png)

- Threads for BST messages or messages within a thread should never be deleted 


Closes #2